### PR TITLE
allow specs to run in rubymine

### DIFF
--- a/spec/gilded_rose_spec.rb
+++ b/spec/gilded_rose_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec'
 require 'lib/gilded_rose'
 
-RSpec.describe '#update_quality' do
+RSpec.describe 'update_quality' do
   context 'with a single' do
     let(:initial_sell_in) { 5 }
     let(:initial_quality) { 10 }


### PR DESCRIPTION
ruby mine blows up when using module syntax in test description. this allows the file to run.